### PR TITLE
`get_interactions_in_area` now also points to `get_interactions_by_taxa`

### DIFF
--- a/R/rglobi.R
+++ b/R/rglobi.R
@@ -202,8 +202,7 @@ get_interactions_in_area <- function(bbox){
   if (is.null(bbox)) {
     stop("no coordinates provided")
   } else {
-    request.url <- get_globi_url("/interaction?type=csv")
-	read.csv(paste(request.url, create_bbox_param(bbox), sep="&"))
+    get_interactions_by_taxa (sourcetaxon = NULL, bbox = bbox)
   }
 }
 


### PR DESCRIPTION
I think, `get_interactions_by_taxa` should be the function to deal with all requests through `/interaction?`. Maybe it makes sense to rename it to simply `get_interactions` and change name of its frontend function `get_interactions` to `get_interactions_by_taxon` (`by_taxa`?)?