### PR TITLE
change travis file to use newer R lang setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,6 @@
-# Sample .travis.yml for R projects.
-#
-# See README.md for instructions, or for more configuration options,
-# see the wiki:
-#   https://github.com/craigcitro/r-travis/wiki
-
-language: c
-
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - ./travis-tool.sh install_deps
-script: ./travis-tool.sh run_tests
-
-after_failure:
-  - ./travis-tool.sh dump_logs
+language: r
+sudo: false
+cache: packages
 
 notifications:
   email:


### PR DESCRIPTION
and cache: packages, sudo: false to speed up builds

hi  - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropensci/rglobi/builds/209108743 isn't faster than the others on the first run, but should be faster the next time since deps are cached