### PR TITLE
Changes for readr 2.0.0

### DIFF
--- a/R/rglobi.R
+++ b/R/rglobi.R
@@ -41,10 +41,15 @@ has_neo4j_api <- function() {
 # @param url points to csv resource
 read_csv_online <- function(url, ...) {
     if (has_api()) {
-      as.data.frame(suppressMessages(readr::read_csv(url)))
-    } else {
-      stop(paste("GloBI data services are not available at [", globi_api_url, "]. Are you connected to the internet?", sep = ""))
+      res <- suppressWarnings(suppressMessages(as.data.frame(readr::read_csv(url))))
+
+      # Drop rows with all NAs
+      res <- res[rowSums(is.na(res)) != ncol(res), ]
+
+      return(res)
     }
+
+    stop(paste("GloBI data services are not available at [", globi_api_url, "]. Are you connected to the internet?", sep = ""))
 }
 
 #' Get Species Interaction from GloBI

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -12,5 +12,10 @@ read_csv_caching = function(url, ...) {
 }
 
 read_csv_offline = function(url, ...) {
-  readr::read_csv(cached_filename(url))
+  res <- suppressWarnings(suppressMessages(as.data.frame(readr::read_csv(cached_filename(url), progress = FALSE))))
+
+  # Drop rows with all NAs
+  res <- res[rowSums(is.na(res)) != ncol(res), ]
+
+  res
 }

--- a/tests/testthat/test-globi.R
+++ b/tests/testthat/test-globi.R
@@ -1,7 +1,5 @@
 context("rglobi")
 
-source('util.R')
-
 test_that("default prey", {
   predatorPrey <- get_prey_of(taxon = "Homo sapiens", read_csv = read_csv_offline)
   expect_true(length(predatorPrey) > 0)


### PR DESCRIPTION
In readr 2.0.0 blank lines are not implicitly skipped. It seems the
GloBI service returns data with a trailing blank line, so we need to
drop these rows with all NA values.

In addition testthat supports a helper file which is automatically
sourced before running your tests or when using `devtools::load_all()`.
I moved the test utils functions into this file.

I also suppressed the parsing warnings as well as the messages, as that
clears up some spurious output when running the tests.

We plan to submit readr 2.0.0 in 2-4 weeks from now. You will need to submit these changes to CRAN before then to avoid test failures on CRAN.