### PR TITLE
Adding warning message when query generates more results than can be returned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,9 @@ Authors@R: c(person("Jorrit", "Poelen", role = c("aut", "cre"),
     person("Stephen", "Gosnell", role = "aut",
     email = "stephen.gosnell@baruch.cuny.edu"),
     person("Sergey", "Slyusarev", role = "aut",
-    email = "cph.lmy@gmail.com"))
+    email = "cph.lmy@gmail.com"),
+    person("Helen", "Waters", role = "aut",
+    email = "helen.waters@ed.ac.uk"))
 URL: https://docs.ropensci.org/rglobi/, https://github.com/ropensci/rglobi
 BugReports: https://github.com/ropensci/rglobi/issues
 VignetteBuilder: knitr

--- a/R/rglobi.R
+++ b/R/rglobi.R
@@ -257,18 +257,16 @@ get_interactions_by_taxa <- function(sourcetaxon, targettaxon = NULL, interactio
   requesturl <- paste(requesturlbase, requestsequence, create_bbox_param(bbox), includeobservations, "type=csv", sep="&")
   result <- read_csv(requesturl)
   
-  if(nrow(result) == 1024){
-    if(ifelse(!"limit" %in% names(otherkeys), TRUE, otherkeys$limit > 1024)){
-      testseq <- requestsequence
-      testseq <- ifelse(grepl("limit=", testseq), gsub("limit=.*?(&|$)", "limit=1\\1", testseq), paste(testseq, "&limit=1", sep=""))
-      testseq <- ifelse(grepl("skip=", testseq), gsub("skip=.*?(&|$)", 
-                                                      paste0("skip=", ifelse("skip" %in% names(otherkeys), otherkeys$skip+1024, 1024), "\\1"),
-                                                      testseq), 
-                        paste(testseq, "&skip=1024", sep=""))
-      testdf <- read_csv(paste(requesturlbase, testseq, create_bbox_param(bbox), includeobservations, "type=csv", sep="&"))
-      if(nrow(testdf) != 0){
-        warning ("Results limit reached. Query generated more results than can be returned via the Web API. Use pagination to retrieve all results.")
-      }
+  if(nrow(result) == 1024 & !"limit" %in% names(otherkeys)){
+    testseq <- paste0(requestsequence, "&limit=1")
+    testseq <- ifelse(grepl("skip=", testseq), 
+                      gsub("skip=.*?(&|$)", 
+                           paste0("skip=", ifelse("skip" %in% names(otherkeys), otherkeys$skip+1024, 1024), "\\1"), 
+                           testseq), 
+                      paste(testseq, "&skip=1024", sep=""))
+    testdf <- read_csv(paste(requesturlbase, testseq, create_bbox_param(bbox), includeobservations, "type=csv", sep="&"))
+    if(nrow(testdf) != 0){
+      warning ("Default results limit reached. Query generated more results than can be returned via the Web API. Increase limit and/or use pagination to retrieve all results.")
     }
   }
 

--- a/R/rglobi.R
+++ b/R/rglobi.R
@@ -258,16 +258,7 @@ get_interactions_by_taxa <- function(sourcetaxon, targettaxon = NULL, interactio
   result <- read_csv(requesturl)
   
   if(nrow(result) == 1024 & !"limit" %in% names(otherkeys)){
-    testseq <- paste0(requestsequence, "&limit=1")
-    testseq <- ifelse(grepl("skip=", testseq), 
-                      gsub("skip=.*?(&|$)", 
-                           paste0("skip=", ifelse("skip" %in% names(otherkeys), otherkeys$skip+1024, 1024), "\\1"), 
-                           testseq), 
-                      paste(testseq, "&skip=1024", sep=""))
-    testdf <- read_csv(paste(requesturlbase, testseq, create_bbox_param(bbox), includeobservations, "type=csv", sep="&"))
-    if(nrow(testdf) != 0){
-      warning ("Default results limit reached. Query generated more results than can be returned via the Web API. Increase limit and/or use pagination to retrieve all results.")
-    }
+    warning("Default results limit reached. Consider increasing limit parameter and/or using pagination to retrieve all results. See rglobi vignette section on pagination for help modifying limit/skip parameters.")
   }
 
   return(result)

--- a/R/rglobi.R
+++ b/R/rglobi.R
@@ -255,7 +255,25 @@ get_interactions_by_taxa <- function(sourcetaxon, targettaxon = NULL, interactio
         ), collapse = "&")
   })()
   requesturl <- paste(requesturlbase, requestsequence, create_bbox_param(bbox), includeobservations, "type=csv", sep="&")
-  read_csv(requesturl)
+  result <- read_csv(requesturl)
+  
+  if(nrow(result) == 1024){
+    if(ifelse(!"limit" %in% names(otherkeys), TRUE, otherkeys$limit > 1024)){
+      testseq <- requestsequence
+      testseq <- ifelse(grepl("limit=", testseq), gsub("limit=.*?(&|$)", "limit=1\\1", testseq), paste(testseq, "&limit=1", sep=""))
+      testseq <- ifelse(grepl("skip=", testseq), gsub("skip=.*?(&|$)", 
+                                                      paste0("skip=", ifelse("skip" %in% names(otherkeys), otherkeys$skip+1024, 1024), "\\1"),
+                                                      testseq), 
+                        paste(testseq, "&skip=1024", sep=""))
+      testdf <- read_csv(paste(requesturlbase, testseq, create_bbox_param(bbox), includeobservations, "type=csv", sep="&"))
+      if(nrow(testdf) != 0){
+        warning ("Results limit reached. Query generated more results than can be returned via the Web API. Use pagination to retrieve all results.")
+      }
+    }
+  }
+
+  return(result)
+  
 }
 
 


### PR DESCRIPTION
Resolves #44 

Here's my potential solution! It involves making an edited URL to read in the 'next' row of data and then checking whether the returned data frame is zero/non-zero. It's not perhaps very elegant, but I couldn't see a straightforward way to perform the check without reading it in first (e.g. using status codes?). Do you think this would slow the function down significantly?

Some notes:
- I've tried to make it robust to whether or not the user specifies a skip option and whatever numeric value it might take.
- If they have specified a limit value, then I am assuming they're aware there could be more data. This is more to warn users who are using the default.
- I've only added it to `get_interactions_by_taxa()`, as it appears to trickle down to all other relevant functions.
- I haven't altered the code for making cypher queries - I'm afraid I'm unfamiliar with cypher, so don't know how that functionality would be added (or if it's required at all?).

Let me know what you think!